### PR TITLE
Fix alfred theme download link

### DIFF
--- a/alfred/README.md
+++ b/alfred/README.md
@@ -4,4 +4,6 @@
 
 ## Install
 
-Download and open this [file](https://github.com/sainnhe/forest-night/raw/master/alfred/Forest+Night.alfredappearance).
+Download and open this [file](https://raw.githubusercontent.com/sainnhe/forest-night/master/alfred/Forest%20Night.alfredappearance).
+
+You can download the file by right clicking the page and selecting "Save As...", just make sure it saves the `alfredappearance` extension.


### PR DESCRIPTION
I thought it would treat the file as a download like it treats Alfred workflows, but it doesn't. This link will show the actual file.